### PR TITLE
👛 Add Wallet button names

### DIFF
--- a/examples/02_bot_example.py
+++ b/examples/02_bot_example.py
@@ -14,6 +14,7 @@ from aiogram.utils.keyboard import InlineKeyboardBuilder
 # install Telegram Wallet Pay API client library:
 #   pip install telegram-wallet-pay
 from telegram_wallet_pay import TelegramWalletPay
+from telegram_wallet_pay.enums import ButtonName
 
 # store TELEGRAM_BOT_API_TOKEN to your .env
 # bot token can be issued via https://t.me/BotFather
@@ -48,7 +49,7 @@ async def message_handler(message: Message, wallet: TelegramWalletPay) -> None:
     # prepare keyboard
     keyboard = InlineKeyboardBuilder()
     wallet_button = InlineKeyboardButton(
-        text="👛 Pay via Wallet",
+        text=ButtonName.PAY_VIA_WALLET,
         url=order.pay_link,
     )
     keyboard.add(wallet_button)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dev = [
     "mypy>=1,<2",
     "pre-commit>=3,<4",
     "fastapi>=0.110,<1",
+    "orjson<3.10.3",
     "uvicorn>=0.29,<1",
     "httpx>=0.27,<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "ruff>=0,<1",
     "mypy>=1,<2",
     "pre-commit>=3,<4",
-    "fastapi-slim>=0.111,<1",
+    "fastapi>=0.110,<1",
     "uvicorn>=0.29,<1",
     "httpx>=0.27,<1",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,7 @@ dev = [
     "ruff>=0,<1",
     "mypy>=1,<2",
     "pre-commit>=3,<4",
-    "fastapi>=0.110,<1",
-    "orjson<3.10.3",
+    "fastapi-slim>=0.111,<1",
     "uvicorn>=0.29,<1",
     "httpx>=0.27,<1",
 ]

--- a/telegram_wallet_pay/__init__.py
+++ b/telegram_wallet_pay/__init__.py
@@ -1,6 +1,15 @@
 __version__ = "0.5.0"
 __api_version__ = "1.2.0"
-__all__ = ["TelegramWalletPay", "enums", "errors", "schemas", "tools"]
+__all__ = [
+    "TelegramWalletPay",
+    "enums",
+    "errors",
+    "schemas",
+    "tools",
+    "WALLET_EMOJI",
+]
 
 from . import enums, errors, schemas, tools
 from .client import TelegramWalletPay
+
+WALLET_EMOJI = "👛"

--- a/telegram_wallet_pay/__init__.py
+++ b/telegram_wallet_pay/__init__.py
@@ -2,6 +2,7 @@ __version__ = "0.5.0"
 __api_version__ = "1.2.0"
 __all__ = [
     "TelegramWalletPay",
+    "constants",
     "enums",
     "errors",
     "schemas",
@@ -9,7 +10,5 @@ __all__ = [
     "WALLET_EMOJI",
 ]
 
-from . import enums, errors, schemas, tools
+from . import constants, enums, errors, schemas, tools
 from .client import TelegramWalletPay
-
-WALLET_EMOJI = "👛"

--- a/telegram_wallet_pay/constants.py
+++ b/telegram_wallet_pay/constants.py
@@ -1,0 +1,1 @@
+WALLET_EMOJI = "👛"

--- a/telegram_wallet_pay/enums/__init__.py
+++ b/telegram_wallet_pay/enums/__init__.py
@@ -1,10 +1,12 @@
 __all__ = [
+    "ButtonName",
     "Currency",
     "OrderStatus",
     "RequestStatus",
     "WebhookMessageType",
 ]
 
+from .button_name import ButtonName
 from .currency import Currency
 from .order_status import OrderStatus
 from .request_status import RequestStatus

--- a/telegram_wallet_pay/enums/button_name.py
+++ b/telegram_wallet_pay/enums/button_name.py
@@ -1,0 +1,16 @@
+from enum import Enum
+
+from telegram_wallet_pay.constants import WALLET_EMOJI
+
+
+class ButtonName(str, Enum):
+    """Enum with available button names.
+
+    The payment button should be named exactly like one of these names.
+
+    Source:
+    https://docs.wallet.tg/pay/#section/Design-Guidelines
+    """
+
+    WALLET_PAY = f"{WALLET_EMOJI} Wallet Pay"
+    PAY_VIA_WALLET = f"{WALLET_EMOJI} Pay via Wallet"


### PR DESCRIPTION
According on [Design Guidelines](https://docs.wallet.tg/pay/#section/Design-Guidelines), the payment button should be named exactly like `👛 Wallet Pay` or `👛 Pay via Wallet`.

In this PR added enum with button names:

```python

from telegram_wallet_pay.enums import ButtonName

print(ButtonName.WALLET_PAY)
# 👛 Wallet Pay

print(ButtonName.PAY_VIA_WALLET)
# 👛 Pay via Wallet

```