### PR TITLE
🐞 Fixed FastAPI slim support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
     "ruff>=0,<1",
     "mypy>=1,<2",
     "pre-commit>=3,<4",
-    "fastapi>=0.110,<1",
+    "fastapi-slim>=0.111,<1",
     "uvicorn>=0.29,<1",
     "httpx>=0.27,<1",
 ]
@@ -65,7 +65,7 @@ test = [
     "pytest-asyncio>=0,<1",
     "pytest-cov>=5,<6",
     "aresponses>=3,<4",
-    "fastapi>=0.110,<1",
+    "fastapi-slim>=0.111,<1",
     "httpx>=0.27,<1",
 ]
 


### PR DESCRIPTION
Due to the fact that [FastAPI 0.111](https://github.com/tiangolo/fastapi/releases/tag/0.111.0) changed the behavior when installing dependencies, our tests, instead of installing the thin FastAPI version, began to try to install extra libraries that cause problems when [building wheels on PyPy](https://github.com/Olegt0rr/TelegramWalletPay/actions/runs/9054744138/job/24874936964)

<img width="1347" alt="Screenshot 2024-05-13 at 02 21 17" src="https://github.com/Olegt0rr/TelegramWalletPay/assets/25399456/65b72643-dae8-42da-adf0-2df538148ddf">
