### PR TITLE
🚸 Added early exception if token is not `str` or empty (#31)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,5 +196,5 @@ max-complexity = 10
 runtime-evaluated-base-classes = ["pydantic.BaseModel", "telegram_wallet_pay.schemas._default.DefaultModel"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/*" = ["D", "FBT001", "INP001", "S101", "SLF001"]
+"tests/*" = ["ANN401", "D", "FBT001", "INP001", "S101", "SLF001"]
 "examples/*" = ["INP001", "T201"]

--- a/telegram_wallet_pay/client.py
+++ b/telegram_wallet_pay/client.py
@@ -56,6 +56,10 @@ class TelegramWalletPay:
     """Telegram Wallet API client."""
 
     def __init__(self, token: str, api_host: str = DEFAULT_API_HOST) -> None:
+        if not token or not isinstance(token, str):
+            msg = f"String token should be provided. You passed: {token}"
+            raise RuntimeError(msg)
+
         self._base_url = api_host
         self._session: Optional[ClientSession] = None
         self._headers = {AUTH_HEADER: token}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,6 +1,6 @@
 import json
 from datetime import datetime
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 
 import pytest
 from aresponses import ResponsesMockServer
@@ -218,3 +218,12 @@ class TestGetOrderAmount:
 class TestSession:
     async def test_close_without_session(self, wallet: TelegramWalletPay) -> None:
         """Test session close without any request."""
+
+
+@pytest.mark.parametrize("token", [None, bool, 42])
+def test_client_init_without_token(token: Any) -> None:
+    """Check passed token is not"""
+    msg = f"String token should be provided. You passed: {token!r}"
+    with pytest.raises(RuntimeError, match=msg):
+        # noinspection PyTypeChecker
+        TelegramWalletPay(token)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -222,7 +222,7 @@ class TestSession:
 
 @pytest.mark.parametrize("token", [None, bool, 42])
 def test_client_init_without_token(token: Any) -> None:
-    """Check passed token is not"""
+    """Check passed token is string and not empty."""
     msg = f"String token should be provided. You passed: {token!r}"
     with pytest.raises(RuntimeError, match=msg):
         # noinspection PyTypeChecker


### PR DESCRIPTION
## Description

In some non-obvious cases, another object may be passed instead of a token (for example, when receiving an environment variable). We need to protect the user by reporting the error in advance.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
