### PR TITLE
💄 Update compute_signature timestamp type hint

### DIFF
--- a/telegram_wallet_pay/tools/signature.py
+++ b/telegram_wallet_pay/tools/signature.py
@@ -10,7 +10,7 @@ def compute_signature(
     store_api_key: str,
     http_method: str,
     uri_path: str,
-    timestamp: str,
+    timestamp: Union[str, float],
     body: Union[str, bytes],
 ) -> str:
     """Compute signature."""


### PR DESCRIPTION
## Description

It's okay to pass `float` to timestamp arg when computing signature


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
